### PR TITLE
Fix commas placement with lists

### DIFF
--- a/moe.go
+++ b/moe.go
@@ -93,7 +93,13 @@ func Rep(s *string, rep [][]string) {
 
 // Print to terminal
 func PrintParams() {
-
+	var pluralKeys = map[string]bool {
+		"Synonyms": true,
+		"Genres": true,
+		"Producers": true,
+		"Licensors": true,
+		"Studios": true,
+	}
 	if info || all {
 		boldblue.Printf("Information\n------------\n")
 		for key, value := range infores {
@@ -104,6 +110,9 @@ func PrintParams() {
 			if key == "Score" {
 				boldgreen.Printf(":  %v\n", scoreres)
 				continue
+			}
+			if _, ok := pluralKeys[key]; ok {
+				value = strings.Replace(value, "  , ", ", ", -1)
 			}
 			boldwhite.Printf(": %v\n", value)
 		}


### PR DESCRIPTION
After parsing MAL's html, there is strange behaviour of the commas
in strings with multiple values:

    $ moe -name "shirobako" -info
    ...
    Producers:  Sotsu  , Movic  , Warner Bros.  , KlockWorx  , Showgate  , Infinite
    Genres   :  Comedy  , Drama
    ...

After this patch commas looks like following:

    $ moe -name "shirobako" -info
    ...
    Genres   :  Comedy, Drama
    Producers:  Sotsu, Movic, Warner Bros., KlockWorx, Showgate, Infinite
    ...